### PR TITLE
Adding lanelet2 dependencies to Docker containers.

### DIFF
--- a/dependencies
+++ b/dependencies
@@ -76,7 +76,9 @@ ros-$ROS_DISTRO-jsk-recognition-msgs
 ros-$ROS_DISTRO-jsk-recognition-utils
 ros-$ROS_DISTRO-jsk-rviz-plugins
 ros-$ROS_DISTRO-jsk-topic-tools
+ros-$ROS_DISTRO-lanelet2
 ros-$ROS_DISTRO-lgsvl-msgs
+ros-$ROS_DISTRO-mrt-cmake-modules
 ros-$ROS_DISTRO-nmea-msgs
 ros-$ROS_DISTRO-nmea-navsat-driver
 ros-$ROS_DISTRO-mrt-cmake-modules


### PR DESCRIPTION
Signed-off-by: Joshua Whitley <josh.whitley@autoware.org>

## New feature implementation

### Implemented feature
Adds `mrt_cmake_modules` and `lanelet2` packages to Docker containers so they don't have to be built from source.