### PR TITLE
Update run.sh with check for nvidia-docker command

### DIFF
--- a/generic/run.sh
+++ b/generic/run.sh
@@ -136,9 +136,14 @@ if [ "$BASE_ONLY" == "true" ]; then
     VOLUMES="$VOLUMES --volume=$AUTOWARE_HOST_DIR:$AUTOWARE_DOCKER_DIR "
 fi
 
+DOCKER_VERSION=$(docker version --format '{{.Client.Version}}' | cut --delimiter=. --fields=1,2)
 if [ $CUDA == "on" ]; then
     SUFFIX=$SUFFIX"-cuda"
-    RUNTIME="--runtime=nvidia"
+    if [[ $DOCKER_VERSION < "19.03" ]] && ! type nvidia-docker; then
+        RUNTIME="--gpus all"
+    else
+        RUNTIME="--runtime=nvidia"
+    fi
 fi
 
 if [ $PRE_RELEASE == "on" ]; then


### PR DESCRIPTION
<!--
For support requests, please ask at ROS Answers: https://answers.ros.org/questions/ask/?tags=autoware, make sure to use the "autoware" tag.
For general questions and design discussion, please use the Autoware Discourse category: https://discourse.ros.org/c/autoware
Not sure if this is the right repository? Open an issue on https://github.com/Autoware-AI/autoware.ai/issues
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix
Nvidia-docker2 deprecated `nvidia-docker` command so run.sh might not work
### Fixed bug
<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

### Fix applied
<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->
nvidia-docker2 deprecated the nvidia-docker command. This change uses the new nvidia-docker argument only if the latest Docker CE is installed and nvidia-docker command is unavailable.

See this MR in Gitlab for successful pipeline: https://gitlab.com/autowarefoundation/autoware.ai/docker/-/merge_requests/45
