### PR TITLE
Fix runtime permission of entrypoint.sh

### DIFF
--- a/generic/Dockerfile
+++ b/generic/Dockerfile
@@ -4,6 +4,7 @@ FROM ${FROM_ARG}
 ARG ROS_DISTRO
 ARG VERSION
 
+USER autoware
 ENV USERNAME autoware
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -20,4 +21,6 @@ RUN echo "source /home/$USERNAME/Autoware/install/local_setup.bash" >> \
     /home/$USERNAME/.bashrc
 
 COPY ./entrypoint.sh /tmp
+# hadolint ignore=DL3002
+USER root
 ENTRYPOINT ["/tmp/entrypoint.sh"]

--- a/generic/Dockerfile.base
+++ b/generic/Dockerfile.base
@@ -84,7 +84,7 @@ RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> /etc/profile.d/ros.sh && \
 COPY ./dependencies /tmp/dependencies
 RUN apt-get update && \
     sed "s/\$ROS_DISTRO/$ROS_DISTRO/g" "/tmp/dependencies" | xargs apt-get install -y && \
-    rm -rf /var/lib/apt/lists/* 
+    rm -rf /var/lib/apt/lists/*
 
 USER autoware
 
@@ -97,4 +97,6 @@ RUN gconftool-2 --set "/apps/gnome-terminal/profiles/Default/use_theme_backgroun
 
 
 COPY ./entrypoint.sh /tmp
+# hadolint ignore=DL3002
+USER root
 ENTRYPOINT ["/tmp/entrypoint.sh"]

--- a/generic/Dockerfile.cuda.kinetic
+++ b/generic/Dockerfile.cuda.kinetic
@@ -3,6 +3,7 @@ FROM nvidia/opengl:1.0-glvnd-runtime-ubuntu16.04 as glvnd_runtime
 # hadolint ignore=DL3006
 FROM ${FROM_ARG}
 
+# hadolint ignore=DL3002
 USER root
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -91,5 +92,4 @@ ENV NVIDIA_DRIVER_CAPABILITIES \
     ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
 ENV AUTOWARE_COMPILE_WITH_CUDA ON
 
-USER autoware
 ENTRYPOINT ["/tmp/entrypoint.sh"]

--- a/generic/Dockerfile.cuda.melodic
+++ b/generic/Dockerfile.cuda.melodic
@@ -3,6 +3,7 @@ FROM nvidia/opengl:1.0-glvnd-runtime-ubuntu18.04 as glvnd_runtime
 # hadolint ignore=DL3006
 FROM ${FROM_ARG}
 
+# hadolint ignore=DL3002
 USER root
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -131,5 +132,4 @@ ENV NVIDIA_DRIVER_CAPABILITIES \
     ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
 ENV AUTOWARE_COMPILE_WITH_CUDA ON
 
-USER autoware
 ENTRYPOINT ["/tmp/entrypoint.sh"]

--- a/generic/entrypoint.sh
+++ b/generic/entrypoint.sh
@@ -9,7 +9,7 @@ DEFAULT_USER_ID=1000
 # to read and write the shared directories.
 #
 if [ -v USER_ID ] && [ "$USER_ID" != "$DEFAULT_USER_ID" ]; then
-    echo "Changing autoware user ID to match your host's user ID ($USER_ID)." 
+    echo "Changing autoware user ID to match your host's user ID ($USER_ID)."
     echo "This operation can take a while..."
 
     usermod --uid $USER_ID autoware
@@ -26,4 +26,5 @@ if [ -z "$1" ]; then
 fi
 
 # Run the provided command using user 'autoware'
-exec "$@"
+export HOME="/home/autoware/"
+chroot --userspec=autoware:autoware --skip-chdir / "$@"


### PR DESCRIPTION
## Commit MSG

In commit 1792f52 the entrypoint.sh is changed to run by autoware user.
This is done because the `gosu` command used to drop from root user to
autoware user does not work on Arm CI. However, this caused the side
effect that `usermod` is prevented from changing the UID of the autoware
user.

In this commit we revert back to running entrypoint.sh as root but drop
to autoware user using the `chroot` command.

Change-Id: Ie4a8e2f72a476e294fb98904faf2f549ffd09847
Issue-ID: SCM-1053
Signed-off-by: Liyou Zhou <liyou.zhou@arm.com>

## Bug fix

### Fixed bug

https://github.com/Autoware-AI/docker/issues/2

### Fix applied

Run entrypoint script as root and drop to user autoware using the chroot command instead of gosu to avoid any problems with the go runtime.