### PR TITLE
Flipped COPY cmds

### DIFF
--- a/generic/Dockerfile.cuda.melodic
+++ b/generic/Dockerfile.cuda.melodic
@@ -118,11 +118,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libx11-dev && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=glvnd_runtime \
-  /usr/lib/x86_64-linux-gnu \
-  /usr/lib/x86_64-linux-gnu
-COPY --from=glvnd_runtime \
   /usr/share/glvnd/egl_vendor.d/10_nvidia.json \
   /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+COPY --from=glvnd_runtime \
+  /usr/lib/x86_64-linux-gnu \
+  /usr/lib/x86_64-linux-gnu
 RUN echo '/usr/lib/x86_64-linux-gnu' >> /etc/ld.so.conf.d/glvnd.conf && \
     ldconfig
 # nvidia-container-runtime


### PR DESCRIPTION
## Bug fix

### Fixed bug
#12 I was not able to reproduce locally but managed to get it shown within the actions of my repo. 

### Fix applied
Flipping both `COPY` instructions seems to do the trick as shown [here](https://github.com/sgermanserrano/docker/runs/1127777691?check_suite_focus=true)
